### PR TITLE
Load averageの取得方法の修正

### DIFF
--- a/cloudflare-uam.sh
+++ b/cloudflare-uam.sh
@@ -4,36 +4,41 @@ api_key=""
 zone_id=""
 
 default_security_level="high"
-max_uptime=2
+max_loadavg=2
 
-if [ "$api_key" = "" ] || [ "$zone_id" = "" ]; then
+if [[ -z $api_key || -z $zone_id ]]; then
     echo "Please set api_key and zone_id."
     exit
 fi
 
-uptime=`uptime | awk '{ print $8 }' | head -c -2`
+if [ ! -e /proc/loadavg ]; then
+    echo "This platform is not supported."
+    exit
+fi
+
+loadavg=`cut -d ' ' -f 1 /proc/loadavg`
 
 # Get Security Level setting
 current_security_level=`curl -X GET "https://api.cloudflare.com/client/v4/zones/$zone_id/settings/security_level" \
     -H "Authorization: Bearer $api_key" \
-    -H "Content-Type: application/json" | jq -r '.result.value'`
+    -H "Content-Type: application/json" | jq -r '.result.value' --silent`
 
-if [ `echo "$max_uptime < $uptime" | bc` = 1 ] && [ $current_security_level = $default_security_level ]; then
+if [ `echo "$max_loadavg < $loadavg" | bc` -eq 1 ] && [ $current_security_level = $default_security_level ]; then
     # Enable Under Attack Mode
     result=`curl -X PATCH "https://api.cloudflare.com/client/v4/zones/$zone_id/settings/security_level" \
         -H "Authorization: Bearer $api_key" \
         -H "Content-Type: application/json" \
-        --data '{"value": "under_attack"}'
+        --data '{"value": "under_attack"}' --silent
         | jq -r '.success'`
     if [ $result = "true" ]; then
         echo "Under Attack mode enabled."
     fi
-elif [ `echo "$max_uptime < $uptime" | bc` != 1 ] && [ $current_security_level = "under_attack" ]; then
+elif [ `echo "$max_loadavg < $loadavg" | bc` -ne 1 ] && [ $current_security_level = "under_attack" ]; then
     # Disable Under Attack Mode
     result=`curl -X PATCH "https://api.cloudflare.com/client/v4/zones/$zone_id/settings/security_level" \
         -H "Authorization: Bearer $api_key" \
         -H "Content-Type: application/json" \
-        --data "{\"value\": \"$default_security_level\"}"
+        --data "{\"value\": \"$default_security_level\"}" --silent
         | jq -r '.success'`
     if [ $result = "true" ]; then
         echo "Under Attack mode disabled."


### PR DESCRIPTION
24時間以上稼働させるとuptimeのフォーマットが変わるので使えなくなるので/proc/loadavgから取得するようにした
```bash
uptime
```
>  20:33:53 up 1 day, 1:47, 1 users, load average: 0.52, 0.58, 0.59
```bash
echo `uptime | awk '{ print $8 }' | head -c -2`
```
> loa
