### PR TITLE
必須コマンド bc, jq, curl の存在チェックを追加

### DIFF
--- a/cloudflare-uam.sh
+++ b/cloudflare-uam.sh
@@ -6,6 +6,15 @@ zone_id=""
 default_security_level="high"
 max_loadavg=2
 
+# Check whether a command exists
+for command in bc jq curl
+do
+    if [[ ! $(type $command 2> /dev/null) ]]; then
+        echo "ERROR: ${command} not found."
+        exit
+    fi
+done
+
 if [[ -z $api_key || -z $zone_id ]]; then
     echo "Please set api_key and zone_id."
     exit


### PR DESCRIPTION
jqコマンドは入っていない環境も結構あるため、はじめに必須OSコマンドの存在チェックを追加しました。

存在チェックはtypeのexit statusを使っています。